### PR TITLE
PR

### DIFF
--- a/components/urls/qr-code.tsx
+++ b/components/urls/qr-code.tsx
@@ -79,14 +79,9 @@ const QRCodeEditor = ({ url, shortId = "custom", urlInfo, children }: QRCodeEdit
           }
         }
 
-        // Fall back to last used style if no URL-specific style is found
-        const lastStyleStr = localStorage.getItem("qrCodeLastStyle")
-        if (lastStyleStr) {
-          const lastStyle = JSON.parse(lastStyleStr)
-          setQrStyles(lastStyle)
-          setPreviousQrStyles(lastStyle)
-        }
-
+        // If no URL-specific style, use default
+        setQrStyles(DEFAULT_QR_STYLES)
+        setPreviousQrStyles(DEFAULT_QR_STYLES)
         setStylesLoaded(true)
       } catch (error) {
         console.error("Error loading saved QR styles:", error)
@@ -100,14 +95,9 @@ const QRCodeEditor = ({ url, shortId = "custom", urlInfo, children }: QRCodeEdit
 
   // Save current style to localStorage when it changes
   useEffect(() => {
-    if (stylesLoaded) {
-      // Always save as the last used style
-      localStorage.setItem("qrCodeLastStyle", JSON.stringify(qrStyles))
-
-      // If we have a specific shortId, also save as URL-specific style
-      if (shortId && shortId !== "custom") {
-        localStorage.setItem(`qrCode_${shortId}`, JSON.stringify(qrStyles))
-      }
+    if (stylesLoaded && shortId && shortId !== "custom") {
+      // Save URL-specific style
+      localStorage.setItem(`qrCode_${shortId}`, JSON.stringify(qrStyles))
     }
   }, [qrStyles, stylesLoaded, shortId])
 
@@ -262,6 +252,7 @@ const QRCodeEditor = ({ url, shortId = "custom", urlInfo, children }: QRCodeEdit
     }
   }
 
+  // Update saveCurrentStyle to only handle global styles
   const saveCurrentStyle = () => {
     if (!currentStyleName.trim()) {
       return
@@ -277,11 +268,17 @@ const QRCodeEditor = ({ url, shortId = "custom", urlInfo, children }: QRCodeEdit
     setCurrentStyleName("")
   }
 
+  // Update loadSavedStyle to handle applying global styles to current QR
   const loadSavedStyle = (styleName: string) => {
     const style = savedStyles[styleName]
     if (style) {
       setPreviousQrStyles(qrStyles)
       setQrStyles(style)
+
+      // Save as URL-specific style if we have a shortId
+      if (shortId && shortId !== "custom") {
+        localStorage.setItem(`qrCode_${shortId}`, JSON.stringify(style))
+      }
     }
   }
 
@@ -332,6 +329,14 @@ const QRCodeEditor = ({ url, shortId = "custom", urlInfo, children }: QRCodeEdit
     })
   }
 
+  // Add function to remove URL-specific style
+  const resetUrlStyle = () => {
+    if (shortId && shortId !== "custom") {
+      localStorage.removeItem(`qrCode_${shortId}`)
+      setQrStyles(DEFAULT_QR_STYLES)
+      setPreviousQrStyles(DEFAULT_QR_STYLES)
+    }
+  }
 
   return (
     <>

--- a/components/urls/save-tab.tsx
+++ b/components/urls/save-tab.tsx
@@ -47,39 +47,43 @@ export const SaveTab = ({
             <Button
               onClick={saveCurrentStyle}
               variant={'primary'}
-              className="flex-1 w-full"
+              className="flex-1 w-full text-xs md:text-sm py-1 md:py-2"
             >
-              <Save className="mr-2 h-4 w-4" />
+              <Save className="mr-1 md:mr-2 h-3 w-3 md:h-4 md:w-4" />
               {t("saveButtons.saveGlobally")}
             </Button>
-            {shortId && shortId !== "custom" && (
-              <Button
-                onClick={saveStyleForCurrentUrl}
-                variant={'primary'}
-              >
-                <Save className="mr-2 h-4 w-4" />
-                {t("saveButtons.saveForThisUrl")}
-              </Button>
-            )}
           </div>
         </div>
 
+        {shortId && shortId !== "custom" && (
+          <div className="pt-1 pb-3 border-b border-gray-100">
+            <Button
+              onClick={saveStyleForCurrentUrl}
+              variant="outline"
+              className="w-full text-xs md:text-sm py-1 md:py-2 border-primary/20 text-primary"
+            >
+              <Save className="mr-1 md:mr-2 h-3 w-3 md:h-4 md:w-4" />
+              {t("saveButtons.saveForThisUrl")}
+            </Button>
+          </div>
+        )}
+
         {Object.keys(savedStyles).length > 0 ? (
-          <div className="space-y-3 mt-4">
+          <div className="space-y-2 mt-3">
             <Label>{t("savedStyles.label")}</Label>
-            <div className="max-h-[200px] overflow-y-auto space-y-2">
+            <div className="max-h-[180px] overflow-y-auto space-y-2">
               {Object.entries(savedStyles).map(([name, _]) => (
                 <div
                   key={name}
-                  className="flex items-center justify-between p-3 bg-gray-50 rounded-md border border-gray-200"
+                  className="flex flex-col sm:flex-row sm:items-center sm:justify-between p-2 md:p-3 bg-gray-50 rounded-md border border-gray-200"
                 >
-                  <span className="font-medium truncate max-w-[150px]">{name}</span>
-                  <div className="flex space-x-2">
+                  <span className="font-medium truncate max-w-full sm:max-w-[150px] mb-1 sm:mb-0">{name}</span>
+                  <div className="flex space-x-1 md:space-x-2 mt-1 sm:mt-0">
                     <Button
                       size="sm"
                       variant="outline"
                       onClick={() => loadSavedStyle(name)}
-                      className="h-8 px-2 text-xs"
+                      className="h-7 md:h-8 px-1 md:px-2 text-xs flex-1 sm:flex-none"
                     >
                       <CheckIcon className="h-3 w-3 mr-1" />
                       {t("savedStyles.actions.apply")}
@@ -88,7 +92,7 @@ export const SaveTab = ({
                       size="sm"
                       variant="destructive"
                       onClick={() => deleteSavedStyle(name)}
-                      className="h-8 px-2 text-xs"
+                      className="h-7 md:h-8 px-1 md:px-2 text-xs"
                     >
                       {t("savedStyles.actions.delete")}
                     </Button>
@@ -98,8 +102,8 @@ export const SaveTab = ({
             </div>
           </div>
         ) : (
-          <div className="flex items-center justify-center p-6 bg-gray-50 border border-gray-200 rounded-md">
-            <p className="text-sm text-gray-500 italic">
+          <div className="flex items-center justify-center p-4 md:p-6 bg-gray-50 border border-gray-200 rounded-md">
+            <p className="text-xs md:text-sm text-gray-500 italic">
               {t("savedStyles.emptyState")}
             </p>
           </div>


### PR DESCRIPTION
This pull request includes several changes to the `QRCodeEditor` and `SaveTab` components to improve the handling of QR code styles and enhance the user interface. The most important changes include updating the logic for saving and loading QR code styles, adding a function to reset URL-specific styles, and refining the UI for better responsiveness and usability.

### Updates to QR code style handling:

* [`components/urls/qr-code.tsx`](diffhunk://#diff-ad423574db488abe12dab1d2e939168b1302d62aedb05120ba535f9b90134f8bL82-R84): Updated the logic to use default QR styles if no URL-specific style is found and to save URL-specific styles only when a valid `shortId` is provided. [[1]](diffhunk://#diff-ad423574db488abe12dab1d2e939168b1302d62aedb05120ba535f9b90134f8bL82-R84) [[2]](diffhunk://#diff-ad423574db488abe12dab1d2e939168b1302d62aedb05120ba535f9b90134f8bL103-L111)
* [`components/urls/qr-code.tsx`](diffhunk://#diff-ad423574db488abe12dab1d2e939168b1302d62aedb05120ba535f9b90134f8bR332-R339): Added a new function to remove URL-specific styles and reset to default QR styles.
* [`components/urls/qr-code.tsx`](diffhunk://#diff-ad423574db488abe12dab1d2e939168b1302d62aedb05120ba535f9b90134f8bR255): Updated `saveCurrentStyle` and `loadSavedStyle` functions to handle global and URL-specific styles appropriately. [[1]](diffhunk://#diff-ad423574db488abe12dab1d2e939168b1302d62aedb05120ba535f9b90134f8bR255) [[2]](diffhunk://#diff-ad423574db488abe12dab1d2e939168b1302d62aedb05120ba535f9b90134f8bR271-R281)

### UI improvements:

* [`components/urls/save-tab.tsx`](diffhunk://#diff-d0c47815529f017b92f9cefe45a7c2b1772df28e27652eec9f8bf09f43fe188eL50-R86): Enhanced the `SaveTab` component's button styles and layout for better responsiveness and usability across different screen sizes. [[1]](diffhunk://#diff-d0c47815529f017b92f9cefe45a7c2b1772df28e27652eec9f8bf09f43fe188eL50-R86) [[2]](diffhunk://#diff-d0c47815529f017b92f9cefe45a7c2b1772df28e27652eec9f8bf09f43fe188eL91-R95) [[3]](diffhunk://#diff-d0c47815529f017b92f9cefe45a7c2b1772df28e27652eec9f8bf09f43fe188eL101-R106)